### PR TITLE
Add LocationConstraint

### DIFF
--- a/Amazon-A2I-and-Rekognition-DetectModerationLabels.ipynb
+++ b/Amazon-A2I-and-Rekognition-DetectModerationLabels.ipynb
@@ -148,7 +148,11 @@
    "source": [
     "# Amazon S3 (S3) client\n",
     "s3 = boto3.client('s3', REGION)\n",
-    "s3.create_bucket(Bucket=BUCKET)\n",
+    "s3.create_bucket(Bucket=BUCKET,\n",
+    "                 CreateBucketConfiguration={\n",
+    "                    'LocationConstraint': REGION,\n",
+    "                 }\n",
+    "                )\n",
     "bucket_region = s3.head_bucket(Bucket=BUCKET)['ResponseMetadata']['HTTPHeaders']['x-amz-bucket-region']\n",
     "assert bucket_region == REGION, \"Your S3 bucket {} and this notebook need to be in the same region.\".format(BUCKET)"
    ]


### PR DESCRIPTION
Currently `s3.create_bucket` requires `LocationConstraint` to create an S3 bucket. The following error raises up without  `LocationConstraint`. This PR fixes the issue.

![スクリーンショット 2021-05-20 14 42 38](https://user-images.githubusercontent.com/10037251/118925405-aaa42e80-b979-11eb-8e94-082a13998ef4.png)
